### PR TITLE
Remove double quotes from ADS comments and do not use flags in re.sub.

### DIFF
--- a/adsbibdesk.py
+++ b/adsbibdesk.py
@@ -660,9 +660,8 @@ class ADSConnector(object):
         """
         try:
             # remove <head>...</head> - often broken HTML
-            self.adsRead = re.sub('<head>.*</head>', '',
-                                  urllib2.urlopen(adsURL).read(),
-                                  flags=re.DOTALL)
+            self.adsRead = re.sub(r'<head>[\s\S]*</head>', '',
+                                  urllib2.urlopen(adsURL).read())
             return True
         except urllib2.HTTPError:
             return False


### PR DESCRIPTION
Fixes #24 and Snow Leopard compatibility.
