### PR TITLE
Compare abstract before replacing publication.

### DIFF
--- a/adsbibdesk.py
+++ b/adsbibdesk.py
@@ -280,10 +280,13 @@ def process_token(articleToken, prefs, bibdesk):
     if found and difflib.SequenceMatcher(None,
                                          bibdesk.authors(bibdesk.pid(found[0]))[0],
                                          ads.author[0]).ratio() > .6:
-        keptPDFs += bibdesk.safe_delete(bibdesk.pid(found[0]))
-        notify('Duplicate publication removed',
-               articleToken, ads.title)
-        bibdesk.refresh()
+        # further comparison on abstract
+        abstract = bibdesk('abstract', bibdesk.pid(found[0])).stringValue()
+        if not abstract or difflib.SequenceMatcher(None, abstract, ads.abstract).ratio() > .6:
+            keptPDFs += bibdesk.safe_delete(bibdesk.pid(found[0]))
+            notify('Duplicate publication removed',
+                   articleToken, ads.title)
+            bibdesk.refresh()
 
     # add new entry
     pub = bibdesk('import from "%s"' % ads.bibtex.__str__().replace('\\', r'\\').replace('"', r'\"'))


### PR DESCRIPTION
Hi Jonathan,

Here's a new patch to compare abstracts (besides author list) when searching for older versions of publications. The old algorithm thinks eg, that both

http://adsabs.harvard.edu/abs/2013arXiv1304.4719C
http://adsabs.harvard.edu/abs/2013arXiv1304.4720C

are the same publication, and thus removes the first one while adding the second. I tested as best as I can (it should be fine for entries without abstract), but it's hard to test all the possible configurations...
