### PR TITLE
Fix to work behind a http proxy.

### DIFF
--- a/adsbibdesk.py
+++ b/adsbibdesk.py
@@ -524,7 +524,11 @@ def hasAnnotations(f):
 
 def getRedirect(url):
     """Utility function to intercept final URL of HTTP redirection"""
-    return urllib2.urlopen(url).geturl()
+    import httplib
+    url = urlparse.urlsplit(url)
+    conn = httplib.HTTPConnection(url.netloc)
+    conn.request('GET', url.path + '?' + url.query)
+    return conn.getresponse().getheader('Location')
 
 
 class PDFDOIGrabber(object):


### PR DESCRIPTION
I found that adsbibtex was timing out on the line

```
conn.request('GET', url.path + '?' + url.query)
```

due to `httplib` not using my proxy settings.

A bit of Googling and I discovered that the same functionality is provided by `urllib2`, which features proxy auto-detection.  It now works fine for me behind a proxy, and I've checked that it still determines the correct mirror (which was the only thing using the `getRedirect` function).
