### PR TITLE
Fix HTTPError and propagate custom BibTeX fields

### DIFF
--- a/adsbibdesk.py
+++ b/adsbibdesk.py
@@ -859,6 +859,11 @@ class BibDesk(object):
         return output
 
     def refresh(self):
+        # is there an opened document yet?
+        if self('return name of first document '
+                'of application "BibDesk"', error=True)[1] is not None:
+            # create blank one
+            self('tell application "BibDesk" to make new document')
         self.titles = self('return title of publications', strlist=True)
         self.ids = self('return id of publications', strlist=True)
 


### PR DESCRIPTION
- try/except PDF connexion for HTTPError (ApJ returns an HTTP 403 forbidden, if you don't have direct access to the PDF)
- propagate custom BibTex fields and BibDesk "annotation" when replacing a publication (mostly for arXiv updater)
